### PR TITLE
Update links for AlphaTestTestNet

### DIFF
--- a/ceremony.md
+++ b/ceremony.md
@@ -39,7 +39,7 @@ ssh-keygen -t rsa
 This is the final step, on which you will create azure virtual machine from a template by filling in a number of fields with data obtained on previous steps. After virtual machine deployment is complete, it will automatically join the Oracles-PoA network and all corresponding activities (voting, payout) will become available to you.
 
 1. Hold <kbd>cmd ⌘</kbd> (on Mac OS X) or <kbd>CTRL</kbd> (on Windows PC) and click on the "Deploy to Azure" button below. This will open a separate browser tab, lead you to azure portal and launch "Custom deployment" wizard (alternatively, you can right-click on the button and select "Open in New Tab")  
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foraclesorg%2Ftest-templates%2Fmaster%2FTestTestNet%2Fmining-node%2Ftemplate.json)
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foraclesorg%2Ftest-templates%2FAlphaTestTestNet%2FTestTestNet%2Fmining-node%2Ftemplate.json)
 
 2. You should see a window similar to this, preselected fields (subscription, location) may be different from yours.
 ![wizard-1a](./docs/ceremony/deploy_wizard1a.png)  


### PR DESCRIPTION
Link of the "Deploy to azure" button needs to be changed to the new alpha-test TestNet.