### PR TITLE
(Fix) Remove Infura RPC/websocket endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ __POA Network is NOT an ERC20 token but is ERC20 Compatible. POA has its own blo
 
 ### Core (live)
 
-- Core (live) RPC infura.io endpoint: `https://poa.infura.io`
-- Core (live) RPC infura.io WebSocket endpoint: `wss://poa.infura.io/ws`
 - Core (live) RPC endpoint: `https://core.poa.network`
 - Core (live) Netstats: [https://core-netstat.poa.network/](https://core-netstat.poa.network/)
 


### PR DESCRIPTION
Remove Infura RPC/websocket endpoints from README

Infura RPC/websocket endpoints [have been disabled](https://forum.poa.network/t/infuras-poa-core-nodes-to-be-disabled-on-2-1-19/1881)

Wiki pages also have been changed in order to remove Infura endpoints:
 - [x] https://github.com/poanetwork/wiki/wiki/Home/6729160a59b0184d32e3a42e79d823e012cc96e1
 - [x] https://github.com/poanetwork/wiki/wiki/POA-Network-on-MetaMask/96ede43f4d4d513c5f4167802d6408fb6bb0fec2